### PR TITLE
Ubiquity 2 rest api update

### DIFF
--- a/controllers/rest/RestApiController.php
+++ b/controllers/rest/RestApiController.php
@@ -28,7 +28,7 @@ class RestApiController extends RestController{
 	 */
 	public function index() {
 		EventsManager::trigger(DefineLocaleEventListener::EVENT_NAME,$this->translator);
-		NormalizersManager::registerClasses([User::class=>UserNormalizer::class,CommentType::class=>CommentTypeNormalizer::class,Comment::class=>CommentNormalizer::class]);
+		NormalizersManager::registerClasses([User::class=>UserNormalizer::class,CommentType::class=>CommentTypeNormalizer::class,Comment::class=>CommentNormalizer::class], $this->translator);
 		$datas=NormalizersManager::normalizeArray_(Service::getUsers());
 		echo $this->_getResponseFormatter()->toJson($datas);
 	}

--- a/controllers/rest/RestApiController.php
+++ b/controllers/rest/RestApiController.php
@@ -28,7 +28,7 @@ class RestApiController extends RestController{
 	 */
 	public function index() {
 		EventsManager::trigger(DefineLocaleEventListener::EVENT_NAME,$this->translator);
-		NormalizersManager::registerClasses([User::class=>UserNormalizer::class,CommentType::class=>CommentTypeNormalizer::class,Comment::class=>CommentNormalizer::class], $this->translator);
+		NormalizersManager::registerClasses([User::class=>UserNormalizer::class,CommentType::class=>CommentTypeNormalizer::class,Comment::class=>CommentNormalizer::class]);
 		$datas=NormalizersManager::normalizeArray_(Service::getUsers());
 		echo $this->_getResponseFormatter()->toJson($datas);
 	}

--- a/eventListener/DefineLocaleEventListener.php
+++ b/eventListener/DefineLocaleEventListener.php
@@ -4,7 +4,6 @@ namespace PhpBenchmarksUbiquity\RestApi\eventListener;
 
 use Ubiquity\events\EventListenerInterface;
 use Ubiquity\utils\http\URequest;
-use Ubiquity\translation\TranslatorManager;
 
 class DefineLocaleEventListener implements EventListenerInterface {
 	
@@ -14,7 +13,7 @@ class DefineLocaleEventListener implements EventListenerInterface {
 		$locales = ['fr_FR', 'en_GB', 'aa_BB'];
 		$locale = $locales[rand(0, 2)];
 		URequest::setLocale($locale);
-		TranslatorManager::setLocale($locale);
+		$params[0]->setLocale($locale);
 	}
 }
 

--- a/eventListener/DefineLocaleEventListener.php
+++ b/eventListener/DefineLocaleEventListener.php
@@ -4,6 +4,7 @@ namespace PhpBenchmarksUbiquity\RestApi\eventListener;
 
 use Ubiquity\events\EventListenerInterface;
 use Ubiquity\utils\http\URequest;
+use Ubiquity\translation\TranslatorManager;
 
 class DefineLocaleEventListener implements EventListenerInterface {
 	
@@ -13,7 +14,7 @@ class DefineLocaleEventListener implements EventListenerInterface {
 		$locales = ['fr_FR', 'en_GB', 'aa_BB'];
 		$locale = $locales[rand(0, 2)];
 		URequest::setLocale($locale);
-		$params[0]->setLocale($locale);
+		TranslatorManager::setLocale($locale);
 	}
 }
 

--- a/normalizer/CommentNormalizer.php
+++ b/normalizer/CommentNormalizer.php
@@ -2,22 +2,12 @@
 
 namespace PhpBenchmarksUbiquity\RestApi\normalizer;
 
-use Ubiquity\translation\Translator;
 use PhpBenchmarksRestData\Comment;
 use Ubiquity\contents\normalizers\NormalizerInterface;
 use Ubiquity\contents\normalizers\NormalizersManager;
+use Ubiquity\translation\TranslatorManager;
 
 class CommentNormalizer implements NormalizerInterface {
-	
-	/**
-	 * @var Translator
-	 */
-	private $translator;
-	
-	
-	public function __construct(Translator $translator){
-		$this->translator=$translator;
-	}
 
 	public function supportsNormalization($data) {
 		return $data instanceof Comment;
@@ -27,7 +17,7 @@ class CommentNormalizer implements NormalizerInterface {
 		return [
 				'id' => $object->getId(),
 				'message' => $object->getMessage(),
-				'translated' => $this->translator->trans('translated.2000', [], 'phpbenchmarks'),
+				'translated' => TranslatorManager::trans('translated.2000', [], 'phpbenchmarks'),
 				'type' => NormalizersManager::normalize_($object->getType())
 		];
 	}

--- a/normalizer/CommentNormalizer.php
+++ b/normalizer/CommentNormalizer.php
@@ -2,12 +2,22 @@
 
 namespace PhpBenchmarksUbiquity\RestApi\normalizer;
 
+use Ubiquity\translation\Translator;
 use PhpBenchmarksRestData\Comment;
 use Ubiquity\contents\normalizers\NormalizerInterface;
 use Ubiquity\contents\normalizers\NormalizersManager;
-use Ubiquity\translation\TranslatorManager;
 
 class CommentNormalizer implements NormalizerInterface {
+	
+	/**
+	 * @var Translator
+	 */
+	private $translator;
+	
+	
+	public function __construct(Translator $translator){
+		$this->translator=$translator;
+	}
 
 	public function supportsNormalization($data) {
 		return $data instanceof Comment;
@@ -17,7 +27,7 @@ class CommentNormalizer implements NormalizerInterface {
 		return [
 				'id' => $object->getId(),
 				'message' => $object->getMessage(),
-				'translated' => TranslatorManager::trans('translated.2000', [], 'phpbenchmarks'),
+				'translated' => $this->translator->trans('translated.2000', [], 'phpbenchmarks'),
 				'type' => NormalizersManager::normalize_($object->getType())
 		];
 	}

--- a/normalizer/CommentTypeNormalizer.php
+++ b/normalizer/CommentTypeNormalizer.php
@@ -16,7 +16,7 @@ class CommentTypeNormalizer implements NormalizerInterface {
 		return [
 				'id' => $object->getId(),
 				'name' => $object->getName(),
-				'translated' => TranslatorManager::tRans('translated.3000', [], 'phpbenchmarks'),
+				'translated' => TranslatorManager::trans('translated.3000', [], 'phpbenchmarks'),
 		];
 	}
 }

--- a/normalizer/CommentTypeNormalizer.php
+++ b/normalizer/CommentTypeNormalizer.php
@@ -2,21 +2,11 @@
 
 namespace PhpBenchmarksUbiquity\RestApi\normalizer;
 
-use Ubiquity\translation\Translator;
 use PhpBenchmarksRestData\CommentType;
 use Ubiquity\contents\normalizers\NormalizerInterface;
+use Ubiquity\translation\TranslatorManager;
 
 class CommentTypeNormalizer implements NormalizerInterface {
-	
-	/**
-	 * @var Translator
-	 */
-	private $translator;
-	
-	
-	public function __construct(Translator $translator){
-		$this->translator=$translator;
-	}
 
 	public function supportsNormalization($data) {
 		return $data instanceof CommentType;
@@ -26,7 +16,7 @@ class CommentTypeNormalizer implements NormalizerInterface {
 		return [
 				'id' => $object->getId(),
 				'name' => $object->getName(),
-				'translated' => $this->translator->trans('translated.3000', [], 'phpbenchmarks'),
+				'translated' => TranslatorManager::tRans('translated.3000', [], 'phpbenchmarks'),
 		];
 	}
 }

--- a/normalizer/CommentTypeNormalizer.php
+++ b/normalizer/CommentTypeNormalizer.php
@@ -2,11 +2,21 @@
 
 namespace PhpBenchmarksUbiquity\RestApi\normalizer;
 
+use Ubiquity\translation\Translator;
 use PhpBenchmarksRestData\CommentType;
 use Ubiquity\contents\normalizers\NormalizerInterface;
-use Ubiquity\translation\TranslatorManager;
 
 class CommentTypeNormalizer implements NormalizerInterface {
+	
+	/**
+	 * @var Translator
+	 */
+	private $translator;
+	
+	
+	public function __construct(Translator $translator){
+		$this->translator=$translator;
+	}
 
 	public function supportsNormalization($data) {
 		return $data instanceof CommentType;
@@ -16,7 +26,7 @@ class CommentTypeNormalizer implements NormalizerInterface {
 		return [
 				'id' => $object->getId(),
 				'name' => $object->getName(),
-				'translated' => TranslatorManager::tRans('translated.3000', [], 'phpbenchmarks'),
+				'translated' => $this->translator->trans('translated.3000', [], 'phpbenchmarks'),
 		];
 	}
 }

--- a/normalizer/UserNormalizer.php
+++ b/normalizer/UserNormalizer.php
@@ -3,11 +3,20 @@
 namespace PhpBenchmarksUbiquity\RestApi\normalizer;
 
 use PhpBenchmarksRestData\User;
+use Ubiquity\translation\Translator;
 use Ubiquity\contents\normalizers\NormalizerInterface;
 use Ubiquity\contents\normalizers\NormalizersManager;
-use Ubiquity\translation\TranslatorManager;
 
 class UserNormalizer implements NormalizerInterface {
+	
+	/**
+	 * @var Translator
+	 */
+	private $translator;
+	
+	public function __construct(Translator $translator){
+		$this->translator=$translator;
+	}
 
 	public function supportsNormalization($data) {
 		return $data instanceof User;
@@ -18,7 +27,7 @@ class UserNormalizer implements NormalizerInterface {
 				'id' => $object->getId(),
 				'login' => $object->getLogin(),
 				'createdAt' => $object->getCreatedAt()->format('Y-m-d H:i:s'),
-				'translated' => TranslatorManager::trans('translated.1000', [], 'phpbenchmarks'),
+				'translated' => $this->translator->trans('translated.1000', [], 'phpbenchmarks'),
 				'comments' => NormalizersManager::normalizeArray_($object->getComments())
 		];
 	}

--- a/normalizer/UserNormalizer.php
+++ b/normalizer/UserNormalizer.php
@@ -3,20 +3,11 @@
 namespace PhpBenchmarksUbiquity\RestApi\normalizer;
 
 use PhpBenchmarksRestData\User;
-use Ubiquity\translation\Translator;
 use Ubiquity\contents\normalizers\NormalizerInterface;
 use Ubiquity\contents\normalizers\NormalizersManager;
+use Ubiquity\translation\TranslatorManager;
 
 class UserNormalizer implements NormalizerInterface {
-	
-	/**
-	 * @var Translator
-	 */
-	private $translator;
-	
-	public function __construct(Translator $translator){
-		$this->translator=$translator;
-	}
 
 	public function supportsNormalization($data) {
 		return $data instanceof User;
@@ -27,7 +18,7 @@ class UserNormalizer implements NormalizerInterface {
 				'id' => $object->getId(),
 				'login' => $object->getLogin(),
 				'createdAt' => $object->getCreatedAt()->format('Y-m-d H:i:s'),
-				'translated' => $this->translator->trans('translated.1000', [], 'phpbenchmarks'),
+				'translated' => TranslatorManager::trans('translated.1000', [], 'phpbenchmarks'),
 				'comments' => NormalizersManager::normalizeArray_($object->getComments())
 		];
 	}


### PR DESCRIPTION
The use of `TranslatorManager` is cleaner than `Translator` : no need to go through the container.
No performance impact